### PR TITLE
Fix package imports and test configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for PII masking framework."""

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -1,0 +1,1 @@
+"""Service submodule providing the FastAPI application."""

--- a/tests/config_test.yaml
+++ b/tests/config_test.yaml
@@ -8,7 +8,7 @@ detection:
   use_ner: false
   custom_regexes:
     - name: "EMAIL"
-      pattern: "[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+"
+      pattern: "[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+"
       policy: HASH
 entities: {}
 masking:


### PR DESCRIPTION
## Summary
- make `src` and `src.service` proper Python packages
- fix regex escaping in `tests/config_test.yaml`
- configure pytest to import from project root

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9863848dc83339e532d49f74c7406