### PR TITLE
Add file encryption/decryption endpoints to FastAPI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ docker build -t pii-masking .
 docker run -p 8000:8000 --env-file .env pii-masking
 ```
 
+### Encrypt and decrypt files
+
+The FastAPI service also exposes simple endpoints for encrypting uploaded files and decrypting the ciphertext.
+
+```bash
+# Encrypt a file
+curl -F "file=@path/to/file.txt" http://localhost:8000/encrypt/upload
+
+# Decrypt (uses the `encrypted_data` field returned above)
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"data": "<ciphertext>"}' http://localhost:8000/decrypt
+```
+
+`FILE_ENCRYPTION_KEY` (a base64 encoded 32-byte key) controls the symmetric key used by these endpoints.
+File uploads require the optional `python-multipart` dependency.
+
 ### 6) Decrypt encrypted values
 ```python
 from src.masking_engine import Config, MaskingEngine

--- a/src/service/app.py
+++ b/src/service/app.py
@@ -1,9 +1,21 @@
 
+import base64
+import importlib
 import os
 from typing import Any, Dict, Optional
 from fastapi import FastAPI, HTTPException
+from starlette.datastructures import UploadFile
 from pydantic import BaseModel
+from cryptography.fernet import Fernet
 from src.masking_engine import Config, MaskingEngine
+
+try:
+    importlib.import_module("multipart")
+    from fastapi import File
+    _multipart_available = True
+except ModuleNotFoundError:  # pragma: no cover - dependency missing in some envs
+    File = None  # type: ignore
+    _multipart_available = False
 
 CONFIG_PATH = os.getenv("MASKING_CONFIG_PATH", "masking_config.yaml")
 
@@ -16,6 +28,13 @@ try:
 except Exception as e:
     raise RuntimeError(f"Failed to load config {CONFIG_PATH}: {e}")
 
+# Encryption key for file APIs
+_enc_key = os.getenv("FILE_ENCRYPTION_KEY")
+if not _enc_key:
+    # Deterministic default for tests if not provided
+    _enc_key = base64.urlsafe_b64encode(b"0" * 32).decode()
+fernet = Fernet(_enc_key)
+
 class TextReq(BaseModel):
     text: str
     context: Optional[Dict[str, str]] = None
@@ -24,6 +43,12 @@ class JsonReq(BaseModel):
     payload: Any
     context: Optional[Dict[str, str]] = None
     also_scan_text_nodes: bool = True
+
+
+class DecryptReq(BaseModel):
+    """Request model for decrypting data."""
+
+    data: str  # base64 encoded ciphertext
 
 @app.get("/health")
 def health():
@@ -42,3 +67,35 @@ def mask_json(req: JsonReq):
         return engine.mask_json(req.payload, context=req.context or {}, also_scan_text_nodes=req.also_scan_text_nodes)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+async def encrypt_upload(file: UploadFile):
+    """Encrypt an uploaded file and return base64 ciphertext."""
+
+    try:
+        contents = await file.read()
+        encrypted = fernet.encrypt(contents)
+        return {
+            "filename": getattr(file, "filename", ""),
+            "encrypted_data": base64.b64encode(encrypted).decode(),
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+if _multipart_available:
+    @app.post("/encrypt/upload")
+    async def encrypt_upload_api(file: UploadFile = File(...)):
+        return await encrypt_upload(file)
+
+
+@app.post("/decrypt")
+def decrypt_data(req: DecryptReq):
+    """Decrypt base64 ciphertext produced by ``/encrypt/upload``."""
+
+    try:
+        encrypted = base64.b64decode(req.data)
+        decrypted = fernet.decrypt(encrypted)
+        return {"decrypted_data": base64.b64encode(decrypted).decode()}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/tests/test_file_encryption_api.py
+++ b/tests/test_file_encryption_api.py
@@ -1,0 +1,26 @@
+import base64
+import io
+import os
+
+# Use test config to avoid loading full masking config
+os.environ.setdefault("MASKING_CONFIG_PATH", "tests/config_test.yaml")
+os.environ.setdefault("FILE_ENCRYPTION_KEY", base64.urlsafe_b64encode(b"0" * 32).decode())
+
+from starlette.datastructures import UploadFile
+import anyio
+
+from src.service.app import encrypt_upload, decrypt_data, DecryptReq
+
+
+async def _roundtrip():
+    original = b"hello world"
+    upload = UploadFile(filename="test.txt", file=io.BytesIO(original))
+    enc_res = await encrypt_upload(upload)
+    enc_data = enc_res["encrypted_data"]
+    dec_res = decrypt_data(DecryptReq(data=enc_data))
+    decrypted_b64 = dec_res["decrypted_data"]
+    assert base64.b64decode(decrypted_b64) == original
+
+
+def test_encrypt_decrypt_file_roundtrip():
+    anyio.run(_roundtrip)


### PR DESCRIPTION
## Summary
- add `/encrypt/upload` endpoint to encrypt uploaded files
- add `/decrypt` endpoint to recover ciphertext
- document file encryption usage and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbe7470fd483339e132953d6f6afdb