### PR TITLE
Add Streamlit file encryption/decryption app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ uvicorn[standard]>=0.23.0
 spacy>=3.7.0
 ff3>=0.1.0
 pytest>=8.0.0
+streamlit>=1.32.0

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,0 +1,45 @@
+"""Simple Streamlit app for encrypting and decrypting files."""
+
+import base64
+import os
+
+import streamlit as st
+from cryptography.fernet import Fernet
+
+
+# Determine encryption key, mirroring the FastAPI service default.
+_enc_key = os.getenv("FILE_ENCRYPTION_KEY")
+if not _enc_key:
+    _enc_key = base64.urlsafe_b64encode(b"0" * 32).decode()
+fernet = Fernet(_enc_key)
+
+
+st.title("File Encrypt/Decrypt")
+
+mode = st.radio("Operation", ["Encrypt", "Decrypt"], horizontal=True)
+uploaded = st.file_uploader("Upload a file")
+
+if uploaded and st.button(mode):
+    data = uploaded.read()
+    try:
+        if mode == "Encrypt":
+            encrypted = fernet.encrypt(data)
+            b64 = base64.b64encode(encrypted).decode()
+            st.text_area("Encrypted data (base64)", b64, height=200)
+            st.download_button(
+                "Download encrypted file",
+                encrypted,
+                file_name=f"{uploaded.name}.enc",
+            )
+        else:
+            decrypted = fernet.decrypt(data)
+            b64 = base64.b64encode(decrypted).decode()
+            st.text_area("Decrypted data (base64)", b64, height=200)
+            st.download_button(
+                "Download decrypted file",
+                decrypted,
+                file_name=f"decrypted_{uploaded.name}",
+            )
+    except Exception as e:  # pragma: no cover - UI feedback
+        st.error(f"{mode}ion failed: {e}")
+


### PR DESCRIPTION
## Summary
- add Streamlit dependency
- introduce a Streamlit UI for uploading files and encrypting or decrypting them with Fernet

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc02dcffe48333a61029bc9a43fe2b