### PR TITLE
fix: import UploadFile from FastAPI

### DIFF
--- a/src/service/app.py
+++ b/src/service/app.py
@@ -5,8 +5,7 @@ import json
 import os
 import re
 from typing import Any, Dict, Optional
-from fastapi import FastAPI, HTTPException
-from starlette.datastructures import UploadFile
+from fastapi import FastAPI, HTTPException, UploadFile
 from pydantic import BaseModel
 from src.masking_engine import Config, MaskingEngine
 


### PR DESCRIPTION
## Summary
- import UploadFile directly from FastAPI to avoid starlette dependency

## Testing
- `pytest`
- `uvicorn src.service.app:app --reload --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_68c29e75f9d88333936bc788e6fc32f7