### PR TITLE
Add synthetic data masking policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A production-ready Python framework to **detect and protect PII** before sending to LLMs or downstream systems.
 - Hybrid detection: **NER (spaCy)** + **Regex** + **Structured key rules for JSON**
-- Transform policies: **REDACT**, **HASH**, **ENCRYPT (AES-GCM)**, **FPE** (optional), **TOKENIZE**
+- Transform policies: **REDACT**, **HASH**, **ENCRYPT (AES-GCM)**, **FPE** (optional), **TOKENIZE**, **SYNTHETIC**
 - Config-first: add new attributes without code changes
 - Run as a **FastAPI service** or a **CLI**
 

--- a/tests/config_synthetic.yaml
+++ b/tests/config_synthetic.yaml
@@ -1,0 +1,15 @@
+language: "en"
+detection:
+  use_regex: false
+  use_ner: false
+  structured_keys:
+    - key: "(?i)^name$"
+      policy: SYNTHETIC
+    - key: "(?i)^address$"
+      policy: SYNTHETIC
+    - key: "(?i)^phone$"
+      policy: SYNTHETIC
+    - key: "(?i)^email$"
+      policy: SYNTHETIC
+masking:
+  default_policy: NONE

--- a/tests/test_synthetic_masking.py
+++ b/tests/test_synthetic_masking.py
@@ -1,0 +1,23 @@
+import re
+from src.masking_engine import Config, MaskingEngine
+
+
+def test_structured_synthetic():
+    cfg = Config.from_yaml("tests/config_synthetic.yaml")
+    engine = MaskingEngine(cfg)
+    data = {
+        "name": "John Doe",
+        "address": "123 Main St",
+        "phone": "+1-555-123-4567",
+        "email": "john@example.com"
+    }
+    res = engine.mask_json(data, also_scan_text_nodes=False)
+    masked = res["masked_json"]
+
+    assert masked["name"] != data["name"]
+    assert masked["address"] != data["address"]
+    assert masked["phone"] != data["phone"]
+    assert masked["email"] != data["email"]
+
+    assert "@" in masked["email"]
+    assert re.search(r"\d", masked["phone"]) is not None


### PR DESCRIPTION
## Summary
- allow generating synthetic replacements for PII with new `SYNTHETIC` policy
- document new masking option
- test structured masking with synthetic data for names, addresses, phones and emails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2ac63331883339d8fd2c2f131f32b