### PR TITLE
Add environment variable validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ python -m spacy download en_core_web_sm
 
 ### 2) Set secrets (examples)
 
+The masking engine reads cryptographic material from environment variables.
+
+**Required**
+
+- `MASKING_AES_KEY_B64` – base64 encoded 32 byte key for AES‑GCM encryption.
+- `MASKING_FPE_KEY_HEX` – hex encoded key used when `fpe.enabled` is `true`.
+
+**Optional**
+
+- `MASKING_SALT_B64` – base64 encoded salt for hashing. Defaults to empty (no salt).
+- `MASKING_TOKEN_SECRET_B64` – base64 encoded secret for deterministic tokens. Defaults to random tokens per value.
+
+If optional variables are unset the engine emits a warning and falls back to
+the listed defaults.
+
 #### Unix/macOS (bash/zsh)
 ```bash
 # 32-byte AES key (base64) for AES-256-GCM

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -1,0 +1,66 @@
+import base64
+import pytest
+
+from src.masking_engine import Config
+
+
+def _write_cfg(tmp_path, content: str) -> str:
+    path = tmp_path / "cfg.yaml"
+    path.write_text(content)
+    return str(path)
+
+
+def test_missing_required_env_aes_key(tmp_path, monkeypatch):
+    cfg_path = _write_cfg(
+        tmp_path,
+        "encryption:\n  key_source: ENV\n  env_key_var: TEST_AES_KEY\n",
+    )
+    # satisfy optional variables
+    monkeypatch.setenv(
+        "MASKING_SALT_B64", base64.b64encode(b"salt").decode()
+    )
+    monkeypatch.setenv(
+        "MASKING_TOKEN_SECRET_B64", base64.b64encode(b"secret").decode()
+    )
+    monkeypatch.delenv("TEST_AES_KEY", raising=False)
+
+    with pytest.raises(ValueError) as exc:
+        Config.from_yaml(cfg_path)
+    assert "TEST_AES_KEY" in str(exc.value)
+
+
+def test_optional_env_warnings(tmp_path, monkeypatch):
+    cfg_path = _write_cfg(tmp_path, "language: en\n")
+    monkeypatch.setenv(
+        "MASKING_AES_KEY_B64", base64.b64encode(b"0" * 32).decode()
+    )
+    monkeypatch.delenv("MASKING_SALT_B64", raising=False)
+    monkeypatch.delenv("MASKING_TOKEN_SECRET_B64", raising=False)
+
+    with pytest.warns(UserWarning) as record:
+        cfg = Config.from_yaml(cfg_path)
+
+    assert cfg.hash_salt == b""
+    assert cfg.token_secret == b""
+    msgs = [str(w.message) for w in record]
+    assert any("MASKING_SALT_B64" in m for m in msgs)
+    assert any("MASKING_TOKEN_SECRET_B64" in m for m in msgs)
+
+
+def test_missing_fpe_key(tmp_path, monkeypatch):
+    cfg_path = _write_cfg(tmp_path, "fpe:\n  enabled: true\n")
+    monkeypatch.setenv(
+        "MASKING_AES_KEY_B64", base64.b64encode(b"0" * 32).decode()
+    )
+    monkeypatch.setenv(
+        "MASKING_SALT_B64", base64.b64encode(b"salt").decode()
+    )
+    monkeypatch.setenv(
+        "MASKING_TOKEN_SECRET_B64", base64.b64encode(b"secret").decode()
+    )
+    monkeypatch.delenv("MASKING_FPE_KEY_HEX", raising=False)
+
+    with pytest.raises(ValueError) as exc:
+        Config.from_yaml(cfg_path)
+    assert "MASKING_FPE_KEY_HEX" in str(exc.value)
+


### PR DESCRIPTION
## Summary
- validate required environment variables for AES and FPE keys
- warn and use defaults when salt or token secret is missing
- document required and optional env vars in README
- add tests covering missing and optional env vars

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b1f2e5d083338946f4308b38b946