### PR TITLE
Add CI workflow and packaging steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pre-commit
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Run tests
+        run: pytest
+
+  package:
+    needs: lint-test
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build wheel
+        run: python -m build
+      - name: Publish to internal PyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_REPOSITORY_URL: ${{ secrets.TWINE_REPOSITORY_URL }}
+        run: |
+          twine upload --skip-existing -r internal dist/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for your interest in contributing to this project!
+
+## Development Workflow
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   pip install pre-commit build twine
+   ```
+2. Install the pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+3. Run the hooks against all files before committing:
+   ```bash
+   pre-commit run --all-files
+   ```
+4. Run the test suite:
+   ```bash
+   pytest
+   ```
+
+## Continuous Integration
+
+Every push and pull request triggers the GitHub Actions workflow defined in `.github/workflows/ci.yml`.
+The pipeline performs the following steps:
+
+- Cache and install dependencies
+- Run `pre-commit` hooks to lint the code
+- Execute the test suite with `pytest`
+- Build a wheel using [`python -m build`](https://pypi.org/project/build/)
+- On tagged commits, upload the built wheel to the internal PyPI using [`twine`](https://pypi.org/project/twine/) and the secrets `TWINE_USERNAME`, `TWINE_PASSWORD`, and `TWINE_REPOSITORY_URL`
+
+By following these steps locally, you can match the checks run in CI.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pre-commit, tests, and build wheel
- set up optional PyPI publishing on tagged releases
- document contribution workflow and CI pipeline

## Testing
- `pytest`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/ci.yml CONTRIBUTING.md` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b1f70fec833397cc127b65572d3a