### PR TITLE
Refactor config loading and streamline service startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,30 @@ $env:MASKING_TOKEN_SECRET_B64 = python -c "import os,base64;print(base64.b64enco
 
 ### 3) Run the API
 
-#### Unix/macOS (bash/zsh)
+The service reads configuration from environment variables or matching CLI
+flags:
+
+- `MASKING_CONFIG_PATH` – config file path (defaults to `masking_config.yaml`)
+- `SERVICE_HOST` – host interface to bind (defaults to `0.0.0.0`)
+- `SERVICE_PORT` – port to listen on (defaults to `8000`)
+- `SERVICE_RELOAD` – enable auto-reload during development
+
+#### Development
+
 ```bash
-export MASKING_CONFIG_PATH=masking_config.yaml
-uvicorn src.service.app:app --reload --port 8000
+MASKING_CONFIG_PATH=masking_config.yaml python -m src.service.app --reload
 ```
 
-#### Windows (PowerShell)
-```powershell
-$env:MASKING_CONFIG_PATH = "masking_config.yaml"
-uvicorn src.service.app:app --reload --port 8000
+#### Production
+
+```bash
+SERVICE_HOST=0.0.0.0 SERVICE_PORT=8000 python -m src.service.app --config /etc/masking.yaml
+```
+
+You can still invoke Uvicorn directly if preferred:
+
+```bash
+uvicorn src.service.app:app --host 0.0.0.0 --port 8000
 ```
 
 ### 4) Use the CLI (same commands for Unix/PowerShell)
@@ -105,10 +119,19 @@ File uploads require the optional `python-multipart` dependency.
 ### Streamlit file encryption UI
 
 For a simple browser interface, run the Streamlit app which uses the same
-`FILE_ENCRYPTION_KEY` as the FastAPI service:
+`FILE_ENCRYPTION_KEY` as the FastAPI service. Set `FILE_ENCRYPTION_KEY` to
+override the default demo key.
+
+#### Development
 
 ```bash
 streamlit run src/streamlit_app.py
+```
+
+#### Production
+
+```bash
+FILE_ENCRYPTION_KEY=<base64key> streamlit run src/streamlit_app.py --server.address 0.0.0.0 --server.port 8501
 ```
 
 The UI lets you upload a file to encrypt or decrypt and download the result.

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,0 +1,44 @@
+import base64
+import os
+from functools import lru_cache
+from typing import Optional
+
+from cryptography.fernet import Fernet
+
+from src.masking_engine import Config, MaskingEngine
+
+DEFAULT_CONFIG_PATH = "masking_config.yaml"
+
+
+@lru_cache()
+def load_config(path: Optional[str] = None) -> Config:
+    """Load the masking configuration.
+
+    Parameters
+    ----------
+    path: Optional[str]
+        Explicit path to the config file. If not provided, the
+        ``MASKING_CONFIG_PATH`` environment variable is used. Defaults
+        to ``masking_config.yaml``.
+    """
+    cfg_path = path or os.getenv("MASKING_CONFIG_PATH", DEFAULT_CONFIG_PATH)
+    return Config.from_yaml(cfg_path)
+
+
+@lru_cache()
+def get_engine(path: Optional[str] = None) -> MaskingEngine:
+    """Initialise and cache a :class:`MaskingEngine` instance."""
+
+    cfg = load_config(path)
+    return MaskingEngine(cfg)
+
+
+@lru_cache()
+def get_file_fernet() -> Fernet:
+    """Return a ``Fernet`` instance for file encryption utilities."""
+
+    key = os.getenv("FILE_ENCRYPTION_KEY")
+    if not key:
+        # Derive a deterministic but insecure default so examples still work
+        key = base64.urlsafe_b64encode(b"0" * 32).decode()
+    return Fernet(key)

--- a/src/service/app.py
+++ b/src/service/app.py
@@ -1,16 +1,18 @@
-
+import argparse
 import base64
 import importlib
 import json
 import os
 import re
 from typing import Any, Dict, Optional
-from fastapi import FastAPI, HTTPException
-from starlette.datastructures import UploadFile
-from pydantic import BaseModel
-from src.masking_engine import Config, MaskingEngine
 
-try:
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from starlette.datastructures import UploadFile
+
+from src.config_loader import get_engine
+
+try:  # Optional dependency for file uploads
     importlib.import_module("multipart")
     from fastapi import File
     _multipart_available = True
@@ -18,120 +20,141 @@ except ModuleNotFoundError:  # pragma: no cover - dependency missing in some env
     File = None  # type: ignore
     _multipart_available = False
 
-CONFIG_PATH = os.getenv("MASKING_CONFIG_PATH", "masking_config.yaml")
 
-app = FastAPI(title="PII Masking Service", version="1.0.0")
+def create_app(config_path: Optional[str] = None) -> FastAPI:
+    """Create the FastAPI app using the shared MaskingEngine."""
 
-# Load config + engine
-try:
-    cfg = Config.from_yaml(CONFIG_PATH)
-    engine = MaskingEngine(cfg)
-except Exception as e:
-    raise RuntimeError(f"Failed to load config {CONFIG_PATH}: {e}")
+    engine = get_engine(config_path)
+    app = FastAPI(title="PII Masking Service", version="1.0.0")
 
+    class TextReq(BaseModel):
+        text: str
+        context: Optional[Dict[str, str]] = None
 
+    class JsonReq(BaseModel):
+        payload: Any
+        context: Optional[Dict[str, str]] = None
+        also_scan_text_nodes: bool = True
 
-class TextReq(BaseModel):
-    text: str
-    context: Optional[Dict[str, str]] = None
+    class DecryptReq(BaseModel):
+        """Request model for decrypting data."""
 
-class JsonReq(BaseModel):
-    payload: Any
-    context: Optional[Dict[str, str]] = None
-    also_scan_text_nodes: bool = True
+        data: str  # base64 encoded ciphertext
 
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
 
-class DecryptReq(BaseModel):
-    """Request model for decrypting data."""
+    @app.post("/mask/text")
+    def mask_text(req: TextReq):
+        try:
+            return engine.mask_text(req.text, context=req.context or {})
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
 
-    data: str  # base64 encoded ciphertext
+    @app.post("/mask/json")
+    def mask_json(req: JsonReq):
+        try:
+            return engine.mask_json(
+                req.payload,
+                context=req.context or {},
+                also_scan_text_nodes=req.also_scan_text_nodes,
+            )
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/health")
-def health():
-    return {"status": "ok"}
+    async def encrypt_upload(file: UploadFile):
+        """Mask an uploaded file and return its base64 representation."""
 
-@app.post("/mask/text")
-def mask_text(req: TextReq):
-    try:
-        return engine.mask_text(req.text, context=req.context or {})
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        try:
+            contents = await file.read()
+            text = contents.decode("utf-8")
+            try:
+                obj = json.loads(text)
+                masked = engine.mask_json(obj)["masked_json"]
+                masked_bytes = json.dumps(masked, ensure_ascii=False).encode("utf-8")
+            except json.JSONDecodeError:
+                masked = engine.mask_text(text)["masked_text"]
+                masked_bytes = masked.encode("utf-8")
+            return {
+                "filename": getattr(file, "filename", ""),
+                "encrypted_data": base64.b64encode(masked_bytes).decode(),
+            }
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/mask/json")
-def mask_json(req: JsonReq):
-    try:
-        return engine.mask_json(req.payload, context=req.context or {}, also_scan_text_nodes=req.also_scan_text_nodes)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    def decrypt_file_contents(data: bytes) -> bytes:
+        """Reverse field-level encryption within the provided file contents."""
 
-
-async def encrypt_upload(file: UploadFile):
-    """Mask an uploaded file and return its base64 representation.
-
-    The file content is inspected; if it contains JSON, ``engine.mask_json`` is
-    applied.  Otherwise the raw text is processed via ``engine.mask_text``.  Only
-    fields detected by the masking engine are encrypted, leaving the overall file
-    structure readable.
-    """
-
-    try:
-        contents = await file.read()
-        text = contents.decode("utf-8")
+        text = data.decode("utf-8")
         try:
             obj = json.loads(text)
-            masked = engine.mask_json(obj)["masked_json"]
-            masked_bytes = json.dumps(masked, ensure_ascii=False).encode("utf-8")
+
+            def walk(node):
+                if isinstance(node, dict):
+                    return {k: walk(v) for k, v in node.items()}
+                if isinstance(node, list):
+                    return [walk(x) for x in node]
+                if isinstance(node, str):
+                    return engine.decrypt_value(node)
+                return node
+
+            decrypted = walk(obj)
+            return json.dumps(decrypted, ensure_ascii=False).encode("utf-8")
         except json.JSONDecodeError:
-            masked = engine.mask_text(text)["masked_text"]
-            masked_bytes = masked.encode("utf-8")
-        return {
-            "filename": getattr(file, "filename", ""),
-            "encrypted_data": base64.b64encode(masked_bytes).decode(),
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+            pattern = re.compile(r"enc:[^\s\"']+")
+
+            def repl(match: re.Match) -> str:
+                return engine.decrypt_value(match.group(0))
+
+            return pattern.sub(repl, text).encode("utf-8")
+
+    if _multipart_available:
+        @app.post("/encrypt/upload")
+        async def encrypt_upload_api(file: UploadFile = File(...)):
+            return await encrypt_upload(file)
+
+    @app.post("/decrypt")
+    def decrypt_data(req: DecryptReq):
+        """Decrypt data previously processed by ``encrypt_upload``."""
+
+        try:
+            masked = base64.b64decode(req.data)
+            decrypted = decrypt_file_contents(masked)
+            return {"decrypted_data": base64.b64encode(decrypted).decode()}
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    # Expose internals for reuse/tests
+    app.state.engine = engine
+    app.state.encrypt_upload = encrypt_upload
+    app.state.decrypt_data = decrypt_data
+    app.state.DecryptReq = DecryptReq
+
+    return app
 
 
-def decrypt_file_contents(data: bytes) -> bytes:
-    """Reverse field-level encryption within the provided file contents."""
+app = create_app()
 
-    text = data.decode("utf-8")
-    try:
-        obj = json.loads(text)
-
-        def walk(node):
-            if isinstance(node, dict):
-                return {k: walk(v) for k, v in node.items()}
-            if isinstance(node, list):
-                return [walk(x) for x in node]
-            if isinstance(node, str):
-                return engine.decrypt_value(node)
-            return node
-
-        decrypted = walk(obj)
-        return json.dumps(decrypted, ensure_ascii=False).encode("utf-8")
-    except json.JSONDecodeError:
-        pattern = re.compile(r"enc:[^\s\"']+")
-
-        def repl(match: re.Match) -> str:
-            return engine.decrypt_value(match.group(0))
-
-        return pattern.sub(repl, text).encode("utf-8")
+# Export utilities for backwards compatibility
+encrypt_upload = app.state.encrypt_upload
+decrypt_data = app.state.decrypt_data
+DecryptReq = app.state.DecryptReq
 
 
-if _multipart_available:
-    @app.post("/encrypt/upload")
-    async def encrypt_upload_api(file: UploadFile = File(...)):
-        return await encrypt_upload(file)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the PII masking API")
+    parser.add_argument(
+        "--config",
+        default=os.getenv("MASKING_CONFIG_PATH", "masking_config.yaml"),
+        help="Path to masking configuration file",
+    )
+    parser.add_argument("--host", default=os.getenv("SERVICE_HOST", "0.0.0.0"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("SERVICE_PORT", "8000")))
+    parser.add_argument("--reload", action="store_true", default=bool(os.getenv("SERVICE_RELOAD")))
+    args = parser.parse_args()
 
+    app = create_app(args.config)
+    import uvicorn
 
-@app.post("/decrypt")
-def decrypt_data(req: DecryptReq):
-    """Decrypt data previously processed by ``encrypt_upload``."""
-
-    try:
-        masked = base64.b64decode(req.data)
-        decrypted = decrypt_file_contents(masked)
-        return {"decrypted_data": base64.b64encode(decrypted).decode()}
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    uvicorn.run(app, host=args.host, port=args.port, reload=args.reload)

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,17 +1,12 @@
 """Simple Streamlit app for encrypting and decrypting files."""
 
 import base64
-import os
 
 import streamlit as st
-from cryptography.fernet import Fernet
 
+from src.config_loader import get_file_fernet
 
-# Determine encryption key, mirroring the FastAPI service default.
-_enc_key = os.getenv("FILE_ENCRYPTION_KEY")
-if not _enc_key:
-    _enc_key = base64.urlsafe_b64encode(b"0" * 32).decode()
-fernet = Fernet(_enc_key)
+fernet = get_file_fernet()
 
 
 st.title("File Encrypt/Decrypt")


### PR DESCRIPTION
## Summary
- centralize MaskingEngine and file encryption key loading
- refactor FastAPI app to use shared loader and expose CLI flags
- update Streamlit UI to reuse common config helpers
- document development/production startup instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2b1f8f5408333beedc1834dd8342f