### PR TITLE
Add project packaging and CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A production-ready Python framework to **detect and protect PII** before sending
 #### Unix/macOS (bash/zsh)
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+pip install .
 # Optional (for NER):
 python -m spacy download en_core_web_sm
 ```
@@ -25,7 +25,7 @@ python -m spacy download en_core_web_sm
 ```powershell
 python -m venv .venv
 .\.venv\Scripts\Activate.ps1
-pip install -r requirements.txt
+pip install .
 # Optional (for NER):
 python -m spacy download en_core_web_sm
 ```
@@ -74,11 +74,11 @@ uvicorn src.service.app:app --reload --port 8000
 The `json` command accepts a single JSON object, a JSON array, or newline-delimited JSON (JSON Lines).
 Each record is masked independently.
 ```bash
-python -m src.cli text "Call me at +91-9876543210 or email a@b.com"
+data-mask text "Call me at +91-9876543210 or email a@b.com"
 # Single JSON object
-python -m src.cli json examples/sample.json
+data-mask json examples/sample.json
 # JSON Lines
-python -m src.cli json examples/sample_lines.jsonl
+data-mask json examples/sample_lines.jsonl
 ```
 ### 5) Docker (optional)
 ```bash
@@ -115,7 +115,7 @@ The UI lets you upload a file to encrypt or decrypt and download the result.
 
 ### 6) Decrypt encrypted values
 ```python
-from src.masking_engine import Config, MaskingEngine
+from src import Config, MaskingEngine
 
 cfg = Config.from_yaml("masking_config.yaml")
 engine = MaskingEngine(cfg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-masking"
+version = "0.1.0"
+description = "PII Masking & Encryption Framework"
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+authors = [{name = "Unknown"}]
+dependencies = [
+    "pyyaml>=6.0.1",
+    "cryptography>=41.0.0",
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.23.0",
+    "spacy>=3.7.0",
+    "ff3>=0.1.0",
+    "streamlit>=1.32.0",
+]
+
+[project.scripts]
+"data-mask" = "src.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["src*"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,5 @@
 """Top-level package for PII masking framework."""
+
+from .masking_engine import Config, MaskingEngine
+
+__all__ = ["Config", "MaskingEngine"]


### PR DESCRIPTION
## Summary
- package project with a new `pyproject.toml` including dependencies and a `data-mask` console script
- re-export `Config` and `MaskingEngine` from the package root
- document installation via `pip install .` and using the `data-mask` CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b1feef5883339522ebf555051d28