### PR TITLE
Add config validation and synthetic masking test config

### DIFF
--- a/src/config/models.py
+++ b/src/config/models.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List, Dict, Any, Optional, Pattern
+import os
+import warnings
+
+from ..utils.io import read_yaml
 
 
 @dataclass
@@ -48,4 +52,39 @@ class Config:
     token_prefix: str
     fpe_enabled: bool
     fpe_cipher: Optional[Any]
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "Config":
+        """Load configuration from *path* with environment validation."""
+        from .loader import load_config
+
+        raw: Dict[str, Any] = read_yaml(path)
+        enc = raw.get("encryption", {})
+        hashing = raw.get("hashing", {})
+        tok = raw.get("tokenization", {})
+        fpe = raw.get("fpe", {})
+
+        if enc.get("key_source", "ENV") == "ENV":
+            var = enc.get("env_key_var", "MASKING_AES_KEY_B64")
+            if not os.getenv(var):
+                raise ValueError(f"Missing required environment variable {var}")
+
+        salt_var = hashing.get("salt_env_var", "MASKING_SALT_B64")
+        if not os.getenv(salt_var):
+            warnings.warn(
+                f"Environment variable {salt_var} is not set; hashing salt will be empty.",
+                UserWarning,
+            )
+
+        token_var = tok.get("secret_env_var", "MASKING_TOKEN_SECRET_B64")
+        if not os.getenv(token_var):
+            warnings.warn(
+                f"Environment variable {token_var} is not set; tokenization will be non-deterministic.",
+                UserWarning,
+            )
+
+        if fpe.get("enabled") and not os.getenv("MASKING_FPE_KEY_HEX"):
+            raise ValueError("Missing required environment variable MASKING_FPE_KEY_HEX")
+
+        return load_config(path)
 

--- a/tests/config_synthetic.yaml
+++ b/tests/config_synthetic.yaml
@@ -1,0 +1,15 @@
+language: en
+detection:
+  use_regex: false
+  use_ner: false
+  structured_keys:
+    - key: "name"
+      policy: SYNTHETIC
+    - key: "address"
+      policy: SYNTHETIC
+    - key: "phone"
+      policy: SYNTHETIC
+    - key: "email"
+      policy: SYNTHETIC
+masking:
+  default_policy: NONE


### PR DESCRIPTION
## Summary
- add Config.from_yaml with environment variable validation
- include synthetic masking test configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2d123ee108333a22dafbefa1462b3