### PR TITLE
Handle dict-style structured key config

### DIFF
--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -30,10 +30,17 @@ def load_config(path: str) -> Config:
     models = raw.get("models", {})
 
     # Structured keys
-    sk = [
-        StructuredKeyRule(key=re.compile(r["key"]), policy=r["policy"].upper())
-        for r in det.get("structured_keys", [])
-    ]
+    sk_cfg = det.get("structured_keys", [])
+    if isinstance(sk_cfg, dict):
+        sk = [
+            StructuredKeyRule(key=re.compile(k), policy=v.upper())
+            for k, v in sk_cfg.items()
+        ]
+    else:
+        sk = [
+            StructuredKeyRule(key=re.compile(r["key"]), policy=r["policy"].upper())
+            for r in sk_cfg
+        ]
 
     # Custom regexes
     rx = [

--- a/tests/test_synthetic_masking.py
+++ b/tests/test_synthetic_masking.py
@@ -1,16 +1,20 @@
 """Tests for masking synthetic structured data."""
 
 import re
+import pytest
 from src.config.loader import create_engine
 
 
-def test_structured_synthetic():
-    engine = create_engine("tests/config_synthetic.yaml")
+@pytest.mark.parametrize(
+    "cfg_path", ["tests/config_synthetic.yaml", "src/synthetic.yaml"]
+)
+def test_structured_synthetic(cfg_path):
+    engine = create_engine(cfg_path)
     data = {
         "name": "John Doe",
         "address": "123 Main St",
         "phone": "+1-555-123-4567",
-        "email": "john@example.com"
+        "email": "john@example.com",
     }
     res = engine.mask_json(data, also_scan_text_nodes=False)
     masked = res["masked_json"]
@@ -22,3 +26,4 @@ def test_structured_synthetic():
 
     assert "@" in masked["email"]
     assert re.search(r"\d", masked["phone"]) is not None
+


### PR DESCRIPTION
## Summary
- fix config loader to support structured_keys provided as a mapping
- test synthetic masking with both list and mapping config formats

## Testing
- `python -m src.cli --config src/synthetic.yaml json examples/raw_synthetic.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2d91638488333b27f9a80f50587ce