### PR TITLE
Add MCP server with mask_pii tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- MCP server exposing a `mask_pii` tool for redacting or hashing emails and phone numbers.
+
 ## [0.1.0] - 2025-09-11
 ### Breaking Changes
 - None.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,29 @@ docker build -t pii-masking .
 docker run -p 8000:8000 --env-file .env pii-masking
 ```
 
+### 6) MCP server (optional)
+
+The framework can also run as a minimal [Model Context Protocol](https://modelcontextprotocol.io/)
+server exposing a ``mask_pii`` tool.  The tool either redacts or hashes e‑mails
+and phone numbers before text is forwarded to an LLM.
+
+```bash
+python -m src.service.mcp_server
+```
+
+Within an MCP-compatible agent the tool can be invoked as::
+
+```python
+mask_pii(text="Email me at a@b.com", mode="redact")
+```
+
+Installing the optional ``mcp`` package is required to run the server:
+
+```bash
+pip install mcp
+```
+
+
 ### Encrypt and decrypt files
 
 The FastAPI service also exposes simple endpoints for encrypting uploaded files and decrypting the ciphertext.

--- a/src/service/mcp_server.py
+++ b/src/service/mcp_server.py
@@ -1,0 +1,63 @@
+"""Minimal MCP server exposing a `mask_pii` tool.
+
+This server provides a single tool to redact or hash email addresses and phone
+numbers before text is sent to an LLM.  It relies only on regular expressions so
+it can run even when the full masking engine or the `mcp` package are
+unavailable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Literal
+
+try:  # pragma: no cover - optional dependency
+    from mcp.server.fastapi import FastAPI
+except Exception:  # pragma: no cover - library might be missing
+    FastAPI = None  # type: ignore
+
+EMAIL_RE = re.compile(r"\b[\w.+-]+@[A-Za-z0-9-]+\.[A-Za-z0-9.-]+\b")
+PHONE_RE = re.compile(r"\b(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?){1,2}\d{4}\b")
+
+
+def _hash(value: str) -> str:
+    """Return a deterministic hash for the provided value."""
+    return "hash_" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def mask_pii(text: str, mode: Literal["redact", "hash"] = "redact") -> str:
+    """Mask e‑mails and phone numbers in ``text``.
+
+    Parameters
+    ----------
+    text:
+        Input string potentially containing PII.
+    mode:
+        ``"redact"`` to replace matches with a token (``[EMAIL]``/``[PHONE]``),
+        or ``"hash"`` to substitute with a deterministic hash.
+    """
+
+    def repl(match: re.Match[str]) -> str:
+        value = match.group(0)
+        if mode == "hash":
+            return _hash(value)
+        return "[EMAIL]" if "@" in value else "[PHONE]"
+
+    text = EMAIL_RE.sub(repl, text)
+    text = PHONE_RE.sub(repl, text)
+    return text
+
+
+if FastAPI:
+    app = FastAPI("PII Masking MCP Server")
+
+    @app.tool()
+    async def mask_pii_tool(
+        text: str, mode: Literal["redact", "hash"] = "redact"
+    ) -> str:
+        """Expose ``mask_pii`` as an MCP tool."""
+        return mask_pii(text, mode)
+
+else:  # pragma: no cover - executed only when FastAPI is missing
+    app = None  # type: ignore

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,20 @@
+import re
+
+from src.service.mcp_server import mask_pii
+
+
+def test_mask_pii_redact():
+    text = "Contact alice@example.com or 123-456-7890"
+    masked = mask_pii(text, mode="redact")
+    assert "alice@example.com" not in masked
+    assert "123-456-7890" not in masked
+    assert "[EMAIL]" in masked
+    assert "[PHONE]" in masked
+
+
+def test_mask_pii_hash():
+    text = "Send details to bob@example.com"
+    masked = mask_pii(text, mode="hash")
+    assert "bob@example.com" not in masked
+    # ensure a sha256 hex digest is present
+    assert re.search(r"hash_[0-9a-f]{64}", masked)


### PR DESCRIPTION
## Summary
- expose a minimal MCP server with a `mask_pii` tool for redacting or hashing emails and phone numbers
- document optional MCP server usage and dependency
- test `mask_pii` behavior and record change in changelog

## Testing
- `python -m black src/service/mcp_server.py tests/test_mcp_server.py`
- `pre-commit run --files CHANGELOG.md README.md src/service/mcp_server.py tests/test_mcp_server.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: No matching distribution found)*
- `flake8 src/service/mcp_server.py tests/test_mcp_server.py` *(fails: command not found)*
- `pip install flake8` *(fails: No matching distribution found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c45caab1988333bc8d14d62b83833c